### PR TITLE
Update fluent.go

### DIFF
--- a/fluent.go
+++ b/fluent.go
@@ -2,7 +2,7 @@ package logrusfluent
 
 import (
 	"fmt"
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	"github.com/fluent/fluent-logger-golang/fluent"
 )
 


### PR DESCRIPTION
Fix bug to use go module
go get -v github.com/mnrtks/logrusfluent
go: finding github.com/mnrtks/logrusfluent latest
go: github.com/Sirupsen/logrus@v1.3.0: parsing go.mod: unexpected module path "github.com/sirupsen/logrus"
go: error loading module requirements